### PR TITLE
プレビューデプロイ + Discord 通知ワークフロー追加

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,92 @@
+name: Deploy Preview & Notify Discord
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'デプロイメッセージ (Discord に表示)'
+        required: false
+        default: '手動デプロイ'
+
+concurrency:
+  group: deploy-preview
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: EAS Update → Discord 通知
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+
+      - run: npm ci
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: EAS Update
+        id: eas-update
+        run: |
+          # タグ or 手動入力のメッセージを決定
+          if [ "${{ github.event_name }}" = "push" ]; then
+            MESSAGE="🏷️ ${{ github.ref_name }}"
+          else
+            MESSAGE="${{ github.event.inputs.message }}"
+          fi
+
+          # EAS Update を実行し、出力を JSON で取得
+          OUTPUT=$(eas update --channel preview --message "$MESSAGE" --non-interactive --json 2>/dev/null)
+
+          # Update Group ID を抽出
+          GROUP_ID=$(echo "$OUTPUT" | jq -r '.[0].group // empty')
+
+          if [ -z "$GROUP_ID" ]; then
+            echo "⚠ Update Group ID を取得できませんでした"
+            echo "update_url=https://expo.dev/accounts/${{ secrets.EXPO_ACCOUNT }}/projects/meet-greet-app/updates" >> "$GITHUB_OUTPUT"
+          else
+            echo "update_url=https://expo.dev/preview/update?message=${MESSAGE}&updateRuntimeVersion=0.1.0&updateGroupId=${GROUP_ID}&updateChannel=preview" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Discord 通知
+        if: success()
+        run: |
+          curl -H "Content-Type: application/json" \
+            -d "$(cat <<EOF
+          {
+            "embeds": [{
+              "title": "📱 ミーグリ記録 プレビュー更新",
+              "description": "${{ steps.eas-update.outputs.message }}",
+              "color": 5763719,
+              "fields": [
+                {
+                  "name": "Expo Go で開く",
+                  "value": "${{ steps.eas-update.outputs.update_url }}"
+                },
+                {
+                  "name": "ブランチ / タグ",
+                  "value": "\`${{ github.ref_name }}\`",
+                  "inline": true
+                },
+                {
+                  "name": "コミット",
+                  "value": "[\`${GITHUB_SHA::7}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})",
+                  "inline": true
+                }
+              ],
+              "footer": {
+                "text": "meet-greet-app | EAS Update (preview channel)"
+              }
+            }]
+          }
+          EOF
+          )" \
+            "${{ secrets.DISCORD_WEBHOOK_URL }}"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: setup dev lint typecheck test check db-start db-reset db-migrate eas-update clean
 
 # mise exec 経由でコマンドを実行し、mise activate なしでも pinned ツールを使えるようにする
+# グローバル設定 (~/.tool-versions, ~/.config/mise/config.toml) を無視し、
+# プロジェクトの .mise.toml のツールだけを対象にする
+export MISE_GLOBAL_CONFIG_FILE := /dev/null
+export MISE_DEFAULT_TOOL_VERSIONS_FILENAME := /dev/null
 MISE := mise exec --
 
 # ============================================================
@@ -11,7 +15,7 @@ MISE := mise exec --
 setup:
 	@command -v mise >/dev/null || (echo "❌ mise がインストールされていません。https://mise.run を参照してください" && exit 1)
 	@echo "→ mise install (Node.js, gitleaks, supabase, eas-cli, codex)..."
-	@mise install
+	@mise install node gitleaks supabase npm:eas-cli npm:@openai/codex
 	@echo "→ dotenvx-rs の確認..."
 	@export PATH="$$HOME/.local/bin:$$PATH" && \
 	command -v dotenvx >/dev/null || ( \

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -13,7 +13,8 @@ cat > "$HOOKS_DIR/pre-commit" << 'HOOK'
 # Gitleaks pre-commit hook: コミット前に機密情報をスキャン
 
 if command -v mise &>/dev/null; then
-  GITLEAKS_CMD="mise exec -- gitleaks"
+  # グローバル設定の Python 等を無視し、プロジェクトのツールだけを対象にする
+  GITLEAKS_CMD="env MISE_GLOBAL_CONFIG_FILE=/dev/null MISE_DEFAULT_TOOL_VERSIONS_FILENAME=/dev/null mise exec -- gitleaks"
 elif command -v gitleaks &>/dev/null; then
   GITLEAKS_CMD="gitleaks"
 else


### PR DESCRIPTION
## 概要

タグ push / 手動実行時に EAS Update でプレビュー配信し、Expo Go で開ける URL を Discord に自動通知するワークフローを追加。

## 変更内容

- `.github/workflows/deploy-preview.yml` 新規追加
  - トリガー: タグ (`v*`) push / `workflow_dispatch` (手動)
  - EAS Update → Update URL 取得 → Discord Webhook で通知
- `Makefile` — `MISE_DEFAULT_TOOL_VERSIONS_FILENAME=/dev/null` 追加 (グローバル設定の Python 無視)
- `scripts/setup-hooks.sh` — pre-commit hook 内でもグローバル設定を無視するよう修正

## 必要な GitHub Secrets

- `EXPO_TOKEN` — EAS 認証トークン (設定済み)
- `EXPO_ACCOUNT` — Expo アカウント名 (例: `kk-shinoda`)
- `DISCORD_WEBHOOK_URL` — Discord Webhook URL

## テスト計画

- [ ] `workflow_dispatch` で手動実行し、Discord にメッセージが届く
- [ ] タグ `v0.1.0` を push し、Discord にメッセージが届く
- [ ] `make setup` がグローバル Python エラーなく完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)