### PR TITLE
GHA ワークフローに Supabase 環境変数を追加

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -63,6 +63,8 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           DEPLOY_MESSAGE: ${{ steps.build.outputs.message }}
+          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
+          EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_ANON_KEY }}
 
       - name: Discord 通知 (成功)
         if: success()

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Create update
         run: eas update --channel preview --message "${{ github.event.head_commit.message }}" --non-interactive
+        env:
+          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
+          EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_ANON_KEY }}

--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -12,10 +12,13 @@ jobs:
     steps:
       - name: Lightweight query
         run: |
-          curl -sf "${SUPABASE_URL}/rest/v1/?limit=0" \
-            -H "apikey: ${SUPABASE_ANON_KEY}" \
-            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
-            -o /dev/null
+          HTTP_STATUS=$(curl -sS --fail-with-body \
+            -w "%{http_code}" \
+            -o /dev/null \
+            "${EXPO_PUBLIC_SUPABASE_URL}/rest/v1/?limit=0" \
+            -H "apikey: ${EXPO_PUBLIC_SUPABASE_ANON_KEY}" \
+            -H "Authorization: Bearer ${EXPO_PUBLIC_SUPABASE_ANON_KEY}")
+          echo "HTTP status: ${HTTP_STATUS}"
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
+          EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## 概要
GHA ワークフローで Supabase の環境変数が渡されておらず、OTA デプロイと keepalive が失敗していた問題を修正。

## 変更内容
- `deploy-testflight.yml`: EAS Update ステップに `EXPO_PUBLIC_SUPABASE_URL/KEY` を追加
- `eas-update.yml`: Create update ステップに同上を追加
- `supabase-keepalive.yml`: `SUPABASE_URL/KEY` → `EXPO_PUBLIC_SUPABASE_URL/KEY` に統一

## 前提
GitHub Secrets に以下が設定済みであること:
- `EXPO_PUBLIC_SUPABASE_URL`
- `EXPO_PUBLIC_SUPABASE_ANON_KEY`

Closes #27

## テスト計画
- [ ] `eas-update.yml` が main マージ時に成功する
- [ ] `supabase-keepalive.yml` を手動実行して成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)