### PR TITLE
ローディングスピナーコンポーネントと ActivityIndicator 警告ルールを追加

### DIFF
--- a/.claude/rules/react-native.md
+++ b/.claude/rules/react-native.md
@@ -16,6 +16,12 @@ paths:
 - 複雑・再利用性の高いスタイルやパフォーマンスが重要な箇所では `StyleSheet.create` も許可する
 - ハードコードされた色・サイズは使わない。NativeWind のテーマまたは定数で管理する
 
+## ローディング表示
+
+- 画面レベル・セクションレベルの非同期待ち (データ取得中等) には `LoadingSpinner` (`components/LoadingSpinner.tsx`) を使う
+- `ActivityIndicator` を画面の読み込み表示に直接使わない。`ActivityIndicator` はボタン内部など局所的なインジケータとしてのみ許可する
+- TanStack Query の `isLoading` / `isPending` 状態では必ず `LoadingSpinner` を表示する
+
 ## 画面コンポーネント (app/ 配下)
 
 - データ取得とレイアウトに集中し、ビジネスロジックはカスタムフックに切り出す

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -1,0 +1,161 @@
+import type { FC } from 'react';
+import { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+type SpinnerSize = 'sm' | 'md' | 'lg';
+
+type LoadingSpinnerProps = {
+  size?: SpinnerSize;
+  color?: string;
+};
+
+const DEFAULT_COLOR = '#5BBEE5';
+
+const TRIANGLE_SIZE: Record<SpinnerSize, number> = {
+  sm: 18,
+  md: 28,
+  lg: 44,
+};
+
+const GAP: Record<SpinnerSize, number> = {
+  sm: 14,
+  md: 22,
+  lg: 34,
+};
+
+const TRIANGLE_COUNT = 3;
+const CYCLE_DURATION_MS = 3000;
+const STAGGER_DELAY_MS = CYCLE_DURATION_MS / TRIANGLE_COUNT;
+
+// キーフレーム: タメ → オーバーシュート回転 → 着地 → 静止
+const WINDUP_ROTATION_DEG = -18;
+const OVERSHOOT_ROTATION_DEG = 390;
+const FULL_ROTATION_DEG = 360;
+const WINDUP_SCALE = 0.85;
+const OVERSHOOT_SCALE = 1.22;
+const REST_SCALE = 1;
+
+const WINDUP_END = 0.05;
+const OVERSHOOT_END = 0.21;
+const SETTLE_END = 0.27;
+
+const WINDUP_DURATION_MS = CYCLE_DURATION_MS * WINDUP_END;
+const SPIN_DURATION_MS = CYCLE_DURATION_MS * (OVERSHOOT_END - WINDUP_END);
+const SETTLE_DURATION_MS = CYCLE_DURATION_MS * (SETTLE_END - OVERSHOOT_END);
+const HOLD_DURATION_MS = CYCLE_DURATION_MS * (1 - SETTLE_END);
+
+const EASING = Easing.bezier(0.5, 0, 0.3, 1);
+
+type TriangleProps = {
+  triangleSize: number;
+  color: string;
+  delay: number;
+};
+
+const Triangle: FC<TriangleProps> = ({ triangleSize, color, delay }) => {
+  const rotation = useSharedValue(0);
+  const scale = useSharedValue(1);
+
+  useEffect(() => {
+    rotation.value = withDelay(
+      delay,
+      withRepeat(
+        withSequence(
+          withTiming(WINDUP_ROTATION_DEG, { duration: WINDUP_DURATION_MS, easing: EASING }),
+          withTiming(OVERSHOOT_ROTATION_DEG, { duration: SPIN_DURATION_MS, easing: EASING }),
+          withTiming(FULL_ROTATION_DEG, { duration: SETTLE_DURATION_MS, easing: EASING }),
+          withTiming(FULL_ROTATION_DEG, { duration: HOLD_DURATION_MS }),
+          // リセット
+          withTiming(0, { duration: 0 }),
+        ),
+        -1,
+      ),
+    );
+
+    scale.value = withDelay(
+      delay,
+      withRepeat(
+        withSequence(
+          withTiming(WINDUP_SCALE, { duration: WINDUP_DURATION_MS, easing: EASING }),
+          withTiming(OVERSHOOT_SCALE, { duration: SPIN_DURATION_MS, easing: EASING }),
+          withTiming(REST_SCALE, { duration: SETTLE_DURATION_MS, easing: EASING }),
+          withTiming(REST_SCALE, { duration: HOLD_DURATION_MS }),
+          withTiming(REST_SCALE, { duration: 0 }),
+        ),
+        -1,
+      ),
+    );
+  }, [delay, rotation, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { rotate: `${rotation.value}deg` },
+      { scale: scale.value },
+    ],
+  }));
+
+  // 直角二等辺三角形 ◣ 型: 左下が直角
+  const triangleStyle = {
+    width: 0,
+    height: 0,
+    borderLeftWidth: triangleSize,
+    borderBottomWidth: triangleSize,
+    borderRightWidth: 0,
+    borderTopWidth: 0,
+    borderLeftColor: 'transparent',
+    borderBottomColor: color,
+    borderRightColor: 'transparent',
+    borderTopColor: 'transparent',
+  };
+
+  return (
+    <Animated.View style={animatedStyle}>
+      <View style={triangleStyle} />
+    </Animated.View>
+  );
+};
+
+export const LoadingSpinner: FC<LoadingSpinnerProps> = ({
+  size = 'md',
+  color = DEFAULT_COLOR,
+}) => {
+  const triangleSize = TRIANGLE_SIZE[size];
+  const gap = GAP[size];
+
+  return (
+    <View
+      accessible
+      accessibilityRole="progressbar"
+      accessibilityLabel="読み込み中"
+      accessibilityState={{ busy: true }}
+      style={[styles.container, { gap }]}
+    >
+      {Array.from({ length: TRIANGLE_COUNT }, (_, i) => (
+        <Triangle
+          key={i}
+          triangleSize={triangleSize}
+          color={color}
+          delay={i * STAGGER_DELAY_MS}
+        />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,4 +7,22 @@ module.exports = defineConfig([
   {
     ignores: ['dist/*'],
   },
+  {
+    files: ['app/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            {
+              name: 'react-native',
+              importNames: ['ActivityIndicator'],
+              message:
+                '画面レベルの読み込み表示には LoadingSpinner を使ってください。ActivityIndicator はボタン等の局所的な用途でのみ許可されています。',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]);


### PR DESCRIPTION
## 概要
アプリの待機中アクション用に、#5BBEE5 の直角二等辺三角形が 3 つ並んでタメ→オーバーシュート→着地で順番に回転するローディングスピナーコンポーネントを追加する。併せて、画面レベルで ActivityIndicator を直接使用することを警告する仕組みを導入する。

## 変更内容
- `components/LoadingSpinner.tsx` — react-native-reanimated によるアニメーション付きローディングスピナー (sm/md/lg サイズ対応)
- `.claude/rules/react-native.md` — ローディング表示のルールを追加 (画面レベルでは LoadingSpinner を使う)
- `eslint.config.js` — `app/` 配下で `ActivityIndicator` の import を警告する `no-restricted-imports` ルールを追加

## テスト計画
- [x] `tsc --noEmit` パス済み
- [x] `expo lint` で LoadingSpinner.tsx にエラー/警告なし
- [x] ESLint ルールが既存の ActivityIndicator 使用箇所 (4 ファイル) を正しく検出
- [ ] 実機で `make dev` → LoadingSpinner を画面に配置して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)